### PR TITLE
added ability to delete and wipe entries

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,14 @@ echo -e "${GREEN}✓ Script installed to $INSTALL_DIR/fzf-cliphist-preview.sh${N
 echo ""
 echo -e "${BLUE}Configuring Hyprland...${NC}"
 
-BINDING_CONTENT='bindd = SUPER SHIFT, V, Clipboard Manager, exec, uwsm app -- kitty --class fzf-clip -o font_size=10 -e sh -c "cliphist list | fzf -d $'\t' --with-nth 2 --preview-window=top:50% --preview '~/.config/omarchy/bin/fzf-cliphist-preview.sh {}' | cliphist decode | wl-copy && wtype -M ctrl -M shift -k v -m ctrl -m shift"'
+BINDING_CONTENT='bindd = ALT, V, Clipboard Manager, exec, uwsm app -- kitty --class fzf-clip -o font_size=10 -e sh -c "cliphist list | fzf -d $'\''\t'\'' \
+    --with-nth 2 \
+    --preview-window=top:50% \
+    --preview '\''~/.config/omarchy/bin/fzf-cliphist-preview.sh {}'\'' \
+    --bind '\''enter:execute(cliphist decode {1} | wl-copy && wtype -M ctrl -M shift -k v -m ctrl -m shift)+abort'\'' \
+    --bind '\''del:execute(cliphist delete <<< {1})+reload(cliphist list)'\'' \
+    --bind '\''ctrl-w:execute(cliphist wipe)+reload(cliphist list)'\''"'
+
 
 WINDOW_RULES='windowrulev2 = size 20% 45%,class:(fzf-clip) # set the size of the window as necessary
 windowrulev2 = float,class:(fzf-clip) # ensure you have a floating window class set if you want this behavior'


### PR DESCRIPTION
Modified the installer script's binding content to include:
- Alt-V:open clipboard
- Enter: select an entry
- Del: deletes the currently hovered clipboard entry (`cliphist delete <<< {1}`)
- Ctrl-W: wipes the entire clipboard database (`cliphist wipe`)

```
BINDING_CONTENT='bindd = ALT, V, Clipboard Manager, exec, uwsm app -- kitty --class fzf-clip -o font_size=10 -e sh -c "cliphist list | fzf -d $'\''\t'\'' \
    --with-nth 2 \
    --preview-window=top:50% \
    --preview '\''~/.config/omarchy/bin/fzf-cliphist-preview.sh {}'\'' \
    --bind '\''enter:execute(cliphist decode {1} | wl-copy && wtype -M ctrl -M shift -k v -m ctrl -m shift)+abort'\'' \
    --bind '\''del:execute(cliphist delete <<< {1})+reload(cliphist list)'\'' \
    --bind '\''ctrl-w:execute(cliphist wipe)+reload(cliphist list)'\''"'

```



https://github.com/user-attachments/assets/063c0b6d-63e6-4317-9039-d275d7e37340

